### PR TITLE
Some changes to non structured commands

### DIFF
--- a/lib/jnpr/junos/command/chassisethernetswitcherrors.yml
+++ b/lib/jnpr/junos/command/chassisethernetswitcherrors.yml
@@ -1,0 +1,10 @@
+---
+EthernetSwitchErrTable:
+  command: show chassis ethernet-switch errors
+  key: fpc
+  view: EthernetSwitchErrView
+
+EthernetSwitchErrView:
+  exists:
+    no_err_port_0: "Error count not available for port 0 connected to device FPC0"
+

--- a/lib/jnpr/junos/command/chassisethernetswitchstatistics.yml
+++ b/lib/jnpr/junos/command/chassisethernetswitchstatistics.yml
@@ -1,0 +1,7 @@
+---
+EthernetSwitchStatistics:
+    command: show chassis ethernet-switch statistics
+    view: EthernetSwitchStatisticsView
+
+EthernetSwitchStatistics:
+    title: Statistics for port 1 connected to device FPC1

--- a/lib/jnpr/junos/command/jnh.yml
+++ b/lib/jnpr/junos/command/jnh.yml
@@ -75,13 +75,3 @@ _RoutingView:
     packets: numbers
     bytes: numbers
 
-JNHIFDStreamTable:
-  command: show jnh ifd 0 stream
-  target: fpc1
-  view: JNHIFDStreamView
-
-JNHIFDStreamView:
-  regex:
-    ifd: ifd = (\d+),
-    stream: Stream = (\d+),
-    pfe_num: PFE-num = (\d+)

--- a/lib/jnpr/junos/command/jnh_exceptions.yml
+++ b/lib/jnpr/junos/command/jnh_exceptions.yml
@@ -1,0 +1,13 @@
+---
+ShowJnhExceptions:
+  command: show jnh 0 exceptions
+  target: fpc2
+  key: reason
+  view: ShowJnhExceptionsView
+
+ShowJnhExceptionsView:
+  regex:
+    reason: '(\w+(\s\w+)*)'
+    type: '((DISC|PUNT)\(\s*\d+\)|M2L ERROR|TRAP\(\))'
+    packets: '\d+'
+    bytes: '\d*'

--- a/lib/jnpr/junos/command/jnh_ifd_stream.yml
+++ b/lib/jnpr/junos/command/jnh_ifd_stream.yml
@@ -1,0 +1,16 @@
+---
+ShowJnhIfdStream:
+  command: show jnh ifd {{ ifd }}  stream
+  args:
+    ifd: 170
+  target: fpc2
+  title: Detail Statistics
+  key: counter
+  view: ShowJnhIfdStreamView
+
+ShowJnhIfdStreamView:
+  regex:
+    counter: '([a-zA-Z0-9-]+):'
+    packets: '(\d+) pkts,'
+    bytes: '(\d+) bytes'
+

--- a/lib/jnpr/junos/command/luchipconfig.yml
+++ b/lib/jnpr/junos/command/luchipconfig.yml
@@ -1,7 +1,0 @@
----
-LUChipConfigTable:
-    command: show chassis ethernet-switch statistics
-    view: LUChipConfigView
-
-LUChipConfigView:
-    title: Statistics for port 1 connected to device FPC1

--- a/lib/jnpr/junos/command/packet_statistics.yml
+++ b/lib/jnpr/junos/command/packet_statistics.yml
@@ -1,0 +1,11 @@
+---
+ShowPacketStatistics:
+  command: show packet statistics
+  target: fpc2
+  key: counter_name
+  view: ShowPacketStatisticsView
+
+ShowPacketStatisticsView:
+  regex:
+    value: numbers
+    counter_name: '(\w+(\s+\w+)*)'

--- a/lib/jnpr/junos/command/systembuffers.yml
+++ b/lib/jnpr/junos/command/systembuffers.yml
@@ -1,0 +1,13 @@
+---
+SystemBuffers:
+  command: show system buffers
+  key: description
+  view: SystemBuffersView
+
+SystemBuffersView:
+  regex:
+    current: '^(\d+)\/'
+    cache: '(\d+)\/'
+    total: '(\d+)\/?'
+    max: '(\d*)'
+    description: '(.*)$'

--- a/lib/jnpr/junos/command/xmchip.yml
+++ b/lib/jnpr/junos/command/xmchip.yml
@@ -36,3 +36,50 @@ XMChipIfdListView:
   filters:
     - ifd_name
     - ifd_index
+
+XMChipQNodeStatsTable:
+  command: show xmchip {{ XM_instance }} q-node stats {{ sched_number }} {{ q_node }}
+  target: fpc2
+  args:
+    XM_instance: 0
+    sched_number: 0
+    q_node: 0
+  key:
+    - index
+    - name
+  view: XMChipQNodeStatsView
+
+XMChipQNodeStatsView:
+  columns:
+    color: Color
+    outcome: Outcome
+    index: Index
+    name: Name
+    total: Total
+    rate: Rate
+
+XMChipDrdErrorTable:
+  command: show xmchip {{ XM_instance }} drd error-stats
+  target: fpc2
+  args:
+    XM_instance: 0
+  key: intr_name
+  view: XMChipDrdErrorView
+
+XMChipDrdErrorView:
+  columns:
+    intr_name: Interrupt Name
+    intr_count: Number of Interrupts
+
+XMChipStatsIngressErrorTable:
+  command: show xmchip {{ XM_instance }} stats ingress-error
+  target: fpc2
+  args:
+    XM_instance: 0
+  key: error_id
+  view: XMChipStatsIngressErrorView
+
+XMChipStatsIngressErrorView:
+  regex:
+    error_id: '([0-9a-zA-Z_]+)\s+:'
+    error_count: numbers


### PR DESCRIPTION
- deleted luchipconfig.yml and ported the logic to chassisethernetswitchstatistics.yml
- removed the JNHIFDStreamTable from jnh.yml as it was not extracting the right data (non local IFD)
- added the following new commands
  > show chassis ethernet-switch errors - (chassisethernetswitcherrors.yml)
  > show jnh 0 exceptions - (jnh_exceptions.yml)
  > show jnh ifd {{ ifd }}  stream - (jnh_ifd_stream.yml)
  > show packet statistics - (packet_statistics.yml)
  > show system buffers - (systembuffers.yml)
  > show xmchip {{ XM_instance }} q-node stats {{ sched_number }} {{ q_node }} (xmchip.yml)
  > show xmchip {{ XM_instance }} drd error-stats (xmchip.yml)
  > show xmchip {{ XM_instance }} stats ingress-error (xmchip.yml)