### PR TITLE
More changes to non structured commands

### DIFF
--- a/lib/jnpr/junos/command/ddos_policer_stats.yml
+++ b/lib/jnpr/junos/command/ddos_policer_stats.yml
@@ -1,0 +1,18 @@
+---
+DdosPolicerStatsTable:
+  command: show ddos policer stats {{ protocol }}
+  args:
+    protocol: ospf
+  target: fpc2
+  key: location
+  view: DdosPolicerStatsView
+
+DdosPolicerStatsView:
+  regex:
+    location: '(UKERN|PFE-[0-9]:[0-9])'
+    pass: \d+
+    drop: \d+
+    arrival_rate: \d+
+    pass_rate: \d+
+    flows: \d+
+

--- a/lib/jnpr/junos/command/jnh_exceptions.yml
+++ b/lib/jnpr/junos/command/jnh_exceptions.yml
@@ -1,6 +1,8 @@
 ---
 ShowJnhExceptions:
-  command: show jnh 0 exceptions
+  command: show jnh {{ jnh_instance }} exceptions
+  args:
+    jnh_instance: 0
   target: fpc2
   key: reason
   view: ShowJnhExceptionsView

--- a/lib/jnpr/junos/command/mtip_cge.yml
+++ b/lib/jnpr/junos/command/mtip_cge.yml
@@ -1,7 +1,7 @@
 ---
 MtipCgeSummaryTable:
   command: show mtip-cge summary
-  target: fpc1
+  target: fpc2
   key: id
   view: MtipCgeSummaryView
 
@@ -13,3 +13,20 @@ MtipCgeSummaryView:
     pic: numbers
     ifd: '(\w+-\d(/\d){2})'
     ptr: "[a-f0-9]+"
+
+MtipCgeStatisticsTable:
+  command: show mtip-cge {{ mtip_id }} statistics
+  args:
+    mtip_id: 11
+  target: fpc2
+  delimiter: ":"
+  view: MtipCgeStatisticsView
+
+MtipCgeStatisticsView:
+  key_items:
+    - aFrameCheckSequenceErrors
+    - aAlignmentErrors
+    - aPAUSEMACCtrlFramesTransmitted
+    - aPAUSEMACCtrlFramesReceived
+    - aFrameTooLongErrors
+    - aInRangeLengthErrors

--- a/lib/jnpr/junos/command/preclstats.yml
+++ b/lib/jnpr/junos/command/preclstats.yml
@@ -1,7 +1,9 @@
 ---
 PreClStatsTable:
-  command: show precl-eng 2 statistics
-  target: fpc1
+  command: show precl-eng {{ precl_index }} statistics
+  target: fpc2
+  args:
+    precl_index: 2
   key:
     - port
     - id

--- a/lib/jnpr/junos/command/show_toe_pfe.yml
+++ b/lib/jnpr/junos/command/show_toe_pfe.yml
@@ -1,0 +1,19 @@
+ShowToePfeTable:
+  command: show toe pfe {{ pfe_instance }} {{ asic_type }} {{ asic_instance }} toe-inst {{ toe_instance }} wedge-stats stream {{ stream_id }}
+  args:
+    pfe_instance: 0
+    asic_type: xm
+    asic_instance: 0
+    toe_instance: 0
+    stream_id: 0
+  target: fpc2
+  view: ShowToePfeView
+
+ShowToePfeView:
+  exists:
+    wedge_not_declared: 'Declared Wedge: NO'
+    wedge_window_size_0: 'Wedge window size: 0'
+    toe_ucode_not_halted: 'TOE ucode halted..................NO'
+    to_asic_not_blocked: 'Suspected to-asic blockage........NO'
+    toe_driver_host_path_app_running: 'TOE driver host path app halted...NO'
+    rx_packets_received: 'RX packets received...YES'

--- a/lib/jnpr/junos/command/xmchip.yml
+++ b/lib/jnpr/junos/command/xmchip.yml
@@ -1,6 +1,8 @@
 ---
 XMChipStatsTable:
-  command: show xmchip 0 pt stats
+  command: show xmchip {{ XM_instance }} pt stats
+  args:
+    XM_instance: 0
   target: fpc1
   view: XMChipStatsView
 


### PR DESCRIPTION
- changed 'show jnh 0 exceptions' to accept jnh instance as a variable
- changed 'show precl-eng 2 statistics' to accept the preclassifier index
  as a variable
- changed 'show xmchip 0 pt stats' to accept the XM ID as a variable
- added the following new commands
  > show ddos policer stats {{ protocol }} (ddos_policer_stats.yml)
  > show mtip-cge {{ mtip_id }} statistics (mtip_cge.yml)
  > show toe pfe {{ pfe_instance }} {{ asic_type }} {{ asic_instance }} toe-inst \
    {{ toe_instance }} wedge-stats stream {{ stream_id }} (show_toe_pfe.yml)