### PR TITLE
Adding PFEStatsErrorMpcType4Table for MPC Type-4

### DIFF
--- a/lib/jnpr/junos/command/pfestatistics.yml
+++ b/lib/jnpr/junos/command/pfestatistics.yml
@@ -118,3 +118,18 @@ _PFELocalProtoStatsView:
   regex:
     value: numbers
     name: words
+
+PFEStatsErrorMpcType4Table:
+  command: show pfe statistics error
+  target: fpc2
+  view: PFEStatsErrorMpcType4View
+
+PFEStatsErrorMpcType4View:
+  fields:
+    FI_Error_stream_counters: _FIErrorstreamCountersTable
+  exists:
+    no_hsl2_errors: 'No errors on this PFE'
+
+_FIErrorstreamCountersTable:
+  title: "Stream number match      : 0x0"
+  delimiter: ":"


### PR DESCRIPTION
Although this is not perfect, this fits better for MPC Type-4.
I just look for HSL2 and FI errors.

However, the two FI stats blocks overlap (same title...) and only one of them comes out after parsing.

```
bash-3.2$ ./pfe_statistics_error.py

SENT: Ukern command: show pfe statistics error



HSL2 Errors:
------------
  *****  No errors on this PFE  *****
LU Chip 0
LUCHIP(0) ISTAT PIO Errors:
    None recorded.
LU Chip 1
LUCHIP(4) ISTAT PIO Errors:
    None recorded.
LU Chip 0
LUCHIP(1) ISTAT PIO Errors:
    None recorded.
LU Chip 1
LUCHIP(5) ISTAT PIO Errors:
    None recorded.

Error Statistics for XM instance 0
----------------------------------

FI error statistics
-------------------

Stream number mask       : 0x0
Stream number match      : 0x0

cell_timeout             : 44
err_cell                 : 0
late_cell                : 0
pt_pkt_errors            : 0
input_buffer_overflow    : 0
input_queue_overflow     : 0
l1_empty                 : 0
l2_empty                 : 0
cp_empty                 : 0
chunk_empty              : 0
ptuse_drops              : 0
pkt_crc_err              : 0

Error Statistics for XM instance 1
----------------------------------

FI error statistics
-------------------

Stream number mask       : 0x0
Stream number match      : 0x0

cell_timeout             : 44
err_cell                 : 0
late_cell                : 0
pt_pkt_errors            : 0
input_buffer_overflow    : 0
input_queue_overflow     : 0
l1_empty                 : 0
l2_empty                 : 0
cp_empty                 : 0
chunk_empty              : 0
ptuse_drops              : 0
pkt_crc_err              : 0


--------------------------------------------------------------------------------

{'FI_Error_stream_counters': {'cell_timeout': 44,
                              'chunk_empty': 0,
                              'cp_empty': 0,
                              'err_cell': 0,
                              'input_buffer_overflow': 0,
                              'input_queue_overflow': 0,
                              'l1_empty': 0,
                              'l2_empty': 0,
                              'late_cell': 0,
                              'pkt_crc_err': 0,
                              'pt_pkt_errors': 0,
                              'ptuse_drops': 0},
 'no_hsl2_errors': True}

```

